### PR TITLE
Fix memory leak caused by excessive settings state polling

### DIFF
--- a/src/frontend/components/settings/Settings.tsx
+++ b/src/frontend/components/settings/Settings.tsx
@@ -52,6 +52,12 @@ export default function Settings() {
         parseResult: parseSettingsStateResult,
         pollMs: 100,
     });
+
+    setInterval(() => {
+        performance.clearMarks();
+        performance.clearMeasures();
+    }, 500);
+
     const hasConfigData = useAtomValue(React.useMemo(() => selectAtom(configAtom, value => value !== undefined), [configAtom]));
     const hasSettingsStateData = useAtomValue(
         React.useMemo(() => selectAtom(settingsStateAtom, value => value !== undefined), [settingsStateAtom]),


### PR DESCRIPTION
Rendering at 100ms causes frequent React state updates, which triggers repeated reconciliation and DOM updates. In Electron’s Chromium renderer, this results in increased scheduling, layout, and transition work being recorded in performance metrics, which can grow rapidly under high-frequency updates. this PR simply adds in a timeout to clear retained performance entry objects this is not a perfect fix ideally we would only update the UI every 1000 ms instead





Contributor agreement 

The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>